### PR TITLE
move initialisation of module to function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,42 @@
-var ENV_NAME = 'TEAMCITY_BUILD_PROPERTIES_FILE';
-
-var filePath = process.env[ENV_NAME];
-if (!filePath) throw new Error('"' + ENV_NAME + '" environment variable is not set. Not running within TeamCity?');
-
 var properties = require('properties');
 
-var fileContents = require('fs').readFileSync(filePath, 'utf-8');
-var teamcityProperties = module.exports = properties.parse(fileContents);
+var ENV_NAME = 'TEAMCITY_BUILD_PROPERTIES_FILE';
+var filePath = process.env[ENV_NAME];
 
-function declareMethod(name, method) {
-    if (name in teamcityProperties) {
-        console.warn('Property "%s" is conflicting with public method. Method skipped, property left unchanged.', name);
-    } else {
-        teamcityProperties[name] = method;
-    }
-}
+module.exports = function() {
+	if (!filePath) throw new Error('"' + ENV_NAME + '" environment variable is not set. Not running within TeamCity?');
 
-/**
- * Access property with presence check.
- * @param {String} key
- * @returns {String|Number|Boolean}
- * @throws when requested key is not defined
- */
-declareMethod('get', function(key) {
-    if (key in teamcityProperties) return teamcityProperties[key];
-    throw new Error('"' + key + '" is not defined in TeamCity build properties. Consider adding it as "system.' + key + '".');
-});
+	var fileContents = require('fs').readFileSync(filePath, 'utf-8');
+	var teamcityProperties = properties.parse(fileContents);
 
-/**
- * Return parsed properties as namespaces (nested objects).
- * @returns {Object}
- */
-declareMethod('namespaces', function() {
-    return properties.parse(fileContents, { namespaces: true });
-});
+	function declareMethod(name, method) {
+		if (name in teamcityProperties) {
+			console.warn('Property "%s" is conflicting with public method. Method skipped, property left unchanged.', name);
+		} else {
+			teamcityProperties[name] = method;
+		}
+	}
+
+	/**
+	 * Access property with presence check.
+	 * @param {String} key
+	 * @returns {String|Number|Boolean}
+	 * @throws when requested key is not defined
+	 */
+	declareMethod('get', function(key) {
+		if (key in teamcityProperties) return teamcityProperties[key];
+		throw new Error(
+			'"' + key + '" is not defined in TeamCity build properties. Consider adding it as "system.' + key + '".'
+		);
+	});
+
+	/**
+	 * Return parsed properties as namespaces (nested objects).
+	 * @returns {Object}
+	 */
+	declareMethod('namespaces', function() {
+		return properties.parse(fileContents, { namespaces: true });
+	});
+
+	return teamcityProperties;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcity-properties",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Access TeamCity build parameters from Node.js",
   "author": "Anton Rudeshko <anton@rudeshko.com>",
   "repository": "https://github.com/anton-rudeshko/teamcity-properties",


### PR DESCRIPTION
When including this module not in a teamcity environment, it immediately errors. This causes scripts that use it to have to be modified if running outside the teamcity env. While one could wrap the require in a try/catch, that isn't exactly the best coding practice. This will allow a user to require the module and then initialise it as a function, allowing the try/catch to go around the fn initialisation, not the require